### PR TITLE
Add self disconnecting signal

### DIFF
--- a/include/pajlada/signals/signal.hpp
+++ b/include/pajlada/signals/signal.hpp
@@ -135,5 +135,34 @@ protected:
 
 using NoArgBoltSignal = BoltSignal<>;
 
+
+/// Disconnects callback when callback is true
+template <class... Args>
+class SelfDisconnectingSignal
+{
+protected:
+    typedef std::function<bool(Args...)> CallbackType;
+
+public:
+    void
+    connect(CallbackType cb)
+    {
+        this->callbacks.push_back(std::move(cb));
+    }
+
+    void
+    invoke(Args... args)
+    {
+        callbacks.erase(std::remove_if(callbacks.begin(), callbacks.end(), [&](CallbackType callback) {
+            return callback(std::forward<Args>(args)...);
+        }), callbacks.end());
+    }
+
+protected:
+    std::vector<CallbackType> callbacks;
+};
+
+using NoArgSelfDisconnectingSignal = SelfDisconnectingSignal<>;
+
 }  // namespace Signals
 }  // namespace pajlada

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -307,3 +307,36 @@ TEST(ScopedConnection, STLContainer)
     incrementSignal.invoke(1);
     EXPECT_EQ(a, 2);
 }
+
+TEST(SelfDisconnectingSignal, MultipleConnects)
+{
+    NoArgSelfDisconnectingSignal signal;
+
+    int a = 0;
+    int b = 0;
+
+    signal.connect([&] {
+        a++;
+        return a == 1;
+    });
+
+    signal.connect([&] {
+        b++;
+        return b == 2;
+    });
+
+    signal.invoke();
+
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 1);
+
+    signal.invoke();
+
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 2);
+
+    signal.invoke();
+
+    EXPECT_EQ(a, 1);
+    EXPECT_EQ(b, 2);
+}


### PR DESCRIPTION
This signal type disconnects itself when the callback function returns true.

Needed for [chatterino2 channel point rewards PR](https://github.com/Chatterino/chatterino2/pull/1809).