### PR TITLE
Loosen ScopedConnection constructors

### DIFF
--- a/include/pajlada/signals/connection.hpp
+++ b/include/pajlada/signals/connection.hpp
@@ -298,21 +298,23 @@ class ScopedConnection
 public:
     ScopedConnection() = default;
 
-    explicit ScopedConnection(ScopedConnection &&other) noexcept
+    ScopedConnection(ScopedConnection &&other) noexcept
         : connection(std::move(other.connection))
     {
     }
 
-    explicit ScopedConnection(Connection &&_connection) noexcept
+    ScopedConnection(Connection &&_connection) noexcept
         : connection(std::move(_connection))
     {
     }
 
+    // Copying a connection may have dangerous unseen side-effects, therefore they may not happen unless explicitly converted
     explicit ScopedConnection(const Connection &other)
         : connection(other)
     {
     }
 
+    // Copying a connection may have dangerous unseen side-effects, therefore they may not happen unless explicitly converted
     explicit ScopedConnection(const ScopedConnection &other)
         : connection(other.connection)
     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -487,6 +487,60 @@ TEST(ScopedConnection, STLContainer)
     EXPECT_EQ(a, 2);
 }
 
+TEST(ScopedConnection, VectorPushBack)
+{
+    Signal<int> incrementSignal;
+    int a = 0;
+    auto IncrementA = [&a](int incrementBy) {
+        a += incrementBy;  //
+    };
+    EXPECT_EQ(a, 0);
+
+    vector<ScopedConnection> scopedConnections;
+
+    {
+        scopedConnections.push_back(incrementSignal.connect(IncrementA));
+
+        incrementSignal.invoke(1);
+        EXPECT_EQ(a, 1);
+    }
+
+    incrementSignal.invoke(1);
+    EXPECT_EQ(a, 2);
+
+    scopedConnections.clear();
+
+    incrementSignal.invoke(1);
+    EXPECT_EQ(a, 2);
+}
+
+TEST(ScopedConnection, VectorEmplaceBack)
+{
+    Signal<int> incrementSignal;
+    int a = 0;
+    auto IncrementA = [&a](int incrementBy) {
+        a += incrementBy;  //
+    };
+    EXPECT_EQ(a, 0);
+
+    vector<ScopedConnection> scopedConnections;
+
+    {
+        scopedConnections.emplace_back(incrementSignal.connect(IncrementA));
+
+        incrementSignal.invoke(1);
+        EXPECT_EQ(a, 1);
+    }
+
+    incrementSignal.invoke(1);
+    EXPECT_EQ(a, 2);
+
+    scopedConnections.clear();
+
+    incrementSignal.invoke(1);
+    EXPECT_EQ(a, 2);
+}
+
 TEST(ScopedConnection, AssignmentOperatorCopyConnection)
 {
     Signal<int> incrementSignal;


### PR DESCRIPTION
This allows ScopedConnection to easier be used in STL containers
