### PR TITLE
Heavily restrict ScopedConnection, forcing users to store it in a unique_ptr instead (or use SignalHolder as the helper)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Breaking: Move ScopedConnection to its own file `pajlada/signals/scoped-connection.hpp`. (#15)
+- Breaking: Heavily restrict ScopedConnection, forcing users to store it in a `unique_ptr` instead (or use `SignalHolder` as the helper). (#18)
 - Dev: Add test for `SignalHolder`. (#17)
 - Dev: Categorize tests by splitting them up into separate files. (#13)
 - Dev: Update version of googletest. (#14)

--- a/include/pajlada/signals/scoped-connection.hpp
+++ b/include/pajlada/signals/scoped-connection.hpp
@@ -11,12 +11,9 @@ class ScopedConnection
     Connection connection;
 
 public:
-    ScopedConnection() = default;
+    ScopedConnection() = delete;
 
-    ScopedConnection(ScopedConnection &&other) noexcept
-        : connection(std::move(other.connection))
-    {
-    }
+    ScopedConnection(ScopedConnection &&other) = delete;
 
     ScopedConnection(Connection &&_connection) noexcept
         : connection(std::move(_connection))
@@ -29,47 +26,15 @@ public:
     {
     }
 
-    // Copying a connection may have dangerous unseen side-effects, therefore they may not happen unless explicitly converted
-    explicit ScopedConnection(const ScopedConnection &other)
-        : connection(other.connection)
-    {
-    }
+    ScopedConnection(const ScopedConnection &other) = delete;
 
-    ScopedConnection &
-    operator=(const Connection &other)
-    {
-        this->connection = other;
+    ScopedConnection &operator=(const Connection &other) = delete;
 
-        return *this;
-    }
+    ScopedConnection &operator=(const ScopedConnection &other) = delete;
 
-    ScopedConnection &
-    operator=(const ScopedConnection &other)
-    {
-        this->connection = other.connection;
+    ScopedConnection &operator=(ScopedConnection &&other) = delete;
 
-        return *this;
-    }
-
-    ScopedConnection &
-    operator=(ScopedConnection &&other) noexcept
-    {
-        if (&other == this) {
-            return *this;
-        }
-
-        this->connection = std::move(other.connection);
-
-        return *this;
-    }
-
-    ScopedConnection &
-    operator=(Connection &&other) noexcept
-    {
-        this->connection = std::move(other);
-
-        return *this;
-    }
+    ScopedConnection &operator=(Connection &&other) = delete;
 
     ~ScopedConnection()
     {

--- a/include/pajlada/signals/signalholder.hpp
+++ b/include/pajlada/signals/signalholder.hpp
@@ -3,6 +3,7 @@
 #include <pajlada/signals/connection.hpp>
 #include <pajlada/signals/scoped-connection.hpp>
 
+#include <memory>
 #include <vector>
 
 namespace pajlada {
@@ -10,7 +11,22 @@ namespace Signals {
 
 class SignalHolder
 {
-    std::vector<ScopedConnection> _managedConnections;
+    std::vector<std::unique_ptr<ScopedConnection>> _managedConnections;
+
+    void
+    add(Connection &&connection)
+    {
+        auto scopedConnection =
+            std::make_unique<ScopedConnection>(std::move(connection));
+
+        this->add(std::move(scopedConnection));
+    }
+
+    void
+    add(std::unique_ptr<ScopedConnection> &&scopedConnection)
+    {
+        this->_managedConnections.emplace_back(std::move(scopedConnection));
+    }
 
 public:
     virtual ~SignalHolder() = default;
@@ -23,20 +39,20 @@ public:
     void
     addConnection(Connection &&connection)
     {
-        this->_managedConnections.emplace_back(connection);
+        this->add(std::move(connection));
     }
 
     template <typename Signal, typename Callback>
     void
     managedConnect(Signal &signal, Callback cb)
     {
-        this->_managedConnections.emplace_back(signal.connect(cb));
+        this->add(std::move(signal.connect(cb)));
     }
 
     void
     emplace_back(Connection &&connection)
     {
-        this->_managedConnections.emplace_back(std::move(connection));
+        this->add(std::move(connection));
     }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,3 @@
-#include <pajlada/signals/signal.hpp>
-
 #include <gtest/gtest.h>
 
 #include <vector>


### PR DESCRIPTION
- Heavily restrict ScopedConnection, forcing users to store it in a unique_ptr instead (or use SignalHolder as the helper)
- Add changelog entry
