### PR TITLE
SignalHolder not being able to be used in pajlada/settings UserManagedConnectionManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Breaking: Move ScopedConnection to its own file `pajlada/signals/scoped-connection.hpp`. (#15)
 - Breaking: Heavily restrict ScopedConnection, forcing users to store it in a `unique_ptr` instead (or use `SignalHolder` as the helper). (#18)
+- Fix: SignalHolder not being able to be used in pajlada/settings UserManagedConnectionManager. (#19)
 - Dev: Add test for `SignalHolder`. (#17)
 - Dev: Categorize tests by splitting them up into separate files. (#13)
 - Dev: Update version of googletest. (#14)

--- a/include/pajlada/signals/signalholder.hpp
+++ b/include/pajlada/signals/signalholder.hpp
@@ -49,10 +49,11 @@ public:
         this->add(std::move(signal.connect(cb)));
     }
 
+    // Ensure this can be used as a UserManagedConnectionManager in pajlada/settings
     void
-    emplace_back(Connection &&connection)
+    emplace_back(std::unique_ptr<ScopedConnection> &&scopedConnection)
     {
-        this->add(std::move(connection));
+        this->add(std::move(scopedConnection));
     }
 };
 


### PR DESCRIPTION
- Ensure SignalHolder can be used as a UserManagedConnectionManager in the pajlada-settings library
- Add changelog entry
