### PR TITLE
Remove unused connection index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Breaking: Heavily restrict ScopedConnection, forcing users to store it in a `unique_ptr` instead (or use `SignalHolder` as the helper). (#18)
 - Minor: Add the `clear` method to `SignalHolder`. (#20)
 - Fix: SignalHolder not being able to be used in pajlada/settings UserManagedConnectionManager. (#19)
+- Fix: Removed unused connection-index. (#26)
 - Dev: Add test for `SignalHolder`. (#17)
 - Dev: Categorize tests by splitting them up into separate files. (#13)
 - Dev: Update version of googletest. (#14)

--- a/include/pajlada/signals/connection.hpp
+++ b/include/pajlada/signals/connection.hpp
@@ -13,16 +13,9 @@ namespace detail {
 class CallbackBodyBase
 {
 protected:
-    CallbackBodyBase() = delete;
-
-    explicit CallbackBodyBase(uint64_t _index)
-        : index(_index)
-    {
-    }
+    explicit CallbackBodyBase() = default;
 
 public:
-    const uint64_t index;
-
     virtual ~CallbackBodyBase() = default;
 
     void
@@ -94,12 +87,7 @@ template <typename... Args>
 class CallbackBody : public CallbackBodyBase
 {
 public:
-    CallbackBody() = delete;
-
-    explicit CallbackBody(uint64_t _index)
-        : CallbackBodyBase(_index)
-    {
-    }
+    explicit CallbackBody() = default;
 
     virtual ~CallbackBody() = default;
 

--- a/include/pajlada/signals/signal.hpp
+++ b/include/pajlada/signals/signal.hpp
@@ -20,9 +20,7 @@ public:
     [[nodiscard]] Connection
     connect(typename CallbackBodyType::FunctionSignature func)
     {
-        uint64_t connectionIndex = this->nextConnection();
-
-        auto callback = std::make_shared<CallbackBodyType>(connectionIndex);
+        auto callback = std::make_shared<CallbackBodyType>();
         callback->func = std::move(func);
 
         std::weak_ptr<CallbackBodyType> weakCallback(callback);
@@ -53,8 +51,6 @@ public:
     }
 
 private:
-    std::atomic<uint64_t> latestConnection{0};
-
     std::mutex callbackBodiesMutex;
     std::vector<std::shared_ptr<CallbackBodyType>> callbackBodies;
 
@@ -91,12 +87,6 @@ private:
         std::unique_lock<std::mutex> lock(this->callbackBodiesMutex);
 
         this->callbackBodies.emplace_back(std::move(body));
-    }
-
-    [[nodiscard]] uint64_t
-    nextConnection()
-    {
-        return ++this->latestConnection;
     }
 };
 


### PR DESCRIPTION
This index was never used. This reduces the size of a signal from 120 B to 112 B and of a connection from 88 B to 80 B.