### PR TITLE
Add missing header for gcc-14

### DIFF
--- a/include/pajlada/signals/signal.hpp
+++ b/include/pajlada/signals/signal.hpp
@@ -2,6 +2,7 @@
 
 #include "pajlada/signals/connection.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <functional>
 #include <memory>


### PR DESCRIPTION
Need to include \<algorithm\> explicitly in order to build with GCC 14.
https://gcc.gnu.org/gcc-14/porting_to.html

```
FAILED: CMakeFiles/signals-test.dir/src/self-disconnecting-signal.cpp.o 
/usr/bin/g++-14 -DPAJLADA_TESTING -I/root/signals/include -isystem /root/signals/external/googletest/googletest/include -isystem /root/signals/external/googletest/googletest -g -std=gnu++17 -MD -MT CMakeFiles/signals-test.dir/src/self-disconnecting-signal.cpp.o -MF CMakeFiles/signals-test.dir/src/self-disconnecting-signal.cpp.o.d -o CMakeFiles/signals-test.dir/src/self-disconnecting-signal.cpp.o -c /root/signals/src/self-disconnecting-signal.cpp
In file included from /root/signals/src/self-disconnecting-signal.cpp:1:
/root/signals/include/pajlada/signals/signal.hpp: In member function 'void pajlada::Signals::SelfDisconnectingSignal<Args>::invoke(Args ...)':
/root/signals/include/pajlada/signals/signal.hpp:146:18: error: 'remove_if' is not a member of 'std'; did you mean 'remove_cv'?
  146 |             std::remove_if(callbacks.begin(), callbacks.end(),
      |                  ^~~~~~~~~
      |                  remove_cv
```