### PR TITLE
fix: build and CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,25 +5,24 @@ Standard: Auto
 PointerBindsToType: false
 Language: Cpp
 SpacesBeforeTrailingComments: 2
-AccessModifierOffset: -1
+AccessModifierOffset: -4
 AlignEscapedNewlinesLeft: true
 AlwaysBreakAfterDefinitionReturnType: true
 AlwaysBreakBeforeMultilineStrings: false
 BreakConstructorInitializersBeforeComma: true
 # BreakBeforeBraces: Linux
 BreakBeforeBraces: Custom
-AccessModifierOffset: -4
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 AllowShortFunctionsOnASingleLine: false
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
 DerivePointerBinding: false
 BraceWrapping: {
-    AfterNamespace: 'false'
-    AfterClass: 'true'
-    BeforeElse: 'false'
-    AfterControlStatement: 'false'
-    AfterFunction: 'true'
+    AfterNamespace: 'false',
+    AfterClass: 'true',
+    BeforeElse: 'false',
+    AfterControlStatement: 'false',
+    AfterFunction: 'true',
     BeforeCatch: 'false'
 }
 ColumnLimit: 80

--- a/.cmake/CodeCoverage.cmake
+++ b/.cmake/CodeCoverage.cmake
@@ -83,6 +83,10 @@
 #     - Change gcovr output from -o <filename> for --xml <filename> and --html <filename> output respectively.
 #       This will allow for Multiple Output Formats at the same time by making use of GCOVR_ADDITIONAL_ARGS, e.g. GCOVR_ADDITIONAL_ARGS "--txt".
 #
+# 2022-09-28, Sebastian Mueller
+#     - fix append_coverage_compiler_flags_to_target to correctly add flags
+#     - replace "-fprofile-arcs -ftest-coverage" with "--coverage" (equivalent)
+#
 # USAGE:
 #
 # 1. Copy this file into your cmake modules path.
@@ -160,13 +164,21 @@ foreach(LANG ${LANGUAGES})
   endif()
 endforeach()
 
-set(COVERAGE_COMPILER_FLAGS "-g -fprofile-arcs -ftest-coverage"
+set(COVERAGE_COMPILER_FLAGS "-g --coverage"
     CACHE INTERNAL "")
+
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
     include(CheckCXXCompilerFlag)
-    check_cxx_compiler_flag(-fprofile-abs-path HAVE_fprofile_abs_path)
-    if(HAVE_fprofile_abs_path)
-        set(COVERAGE_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+    check_cxx_compiler_flag(-fprofile-abs-path HAVE_cxx_fprofile_abs_path)
+    if(HAVE_cxx_fprofile_abs_path)
+        set(COVERAGE_CXX_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
+    endif()
+endif()
+if(CMAKE_C_COMPILER_ID MATCHES "(GNU|Clang)")
+    include(CheckCCompilerFlag)
+    check_c_compiler_flag(-fprofile-abs-path HAVE_c_fprofile_abs_path)
+    if(HAVE_c_fprofile_abs_path)
+        set(COVERAGE_C_COMPILER_FLAGS "${COVERAGE_COMPILER_FLAGS} -fprofile-abs-path")
     endif()
 endif()
 
@@ -258,40 +270,40 @@ function(setup_target_for_coverage_lcov)
     if(CPPFILT_PATH AND NOT ${Coverage_NO_DEMANGLE})
       set(GENHTML_EXTRA_ARGS "--demangle-cpp")
     endif()
-     
+
     # Setting up commands which will be run to generate coverage data.
     # Cleanup lcov
-    set(LCOV_CLEAN_CMD 
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -directory . 
+    set(LCOV_CLEAN_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory .
         -b ${BASEDIR} --zerocounters
     )
     # Create baseline to make sure untouched files show up in the report
-    set(LCOV_BASELINE_CMD 
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b 
+    set(LCOV_BASELINE_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -c -i -d . -b
         ${BASEDIR} -o ${Coverage_NAME}.base
     )
     # Run tests
-    set(LCOV_EXEC_TESTS_CMD 
+    set(LCOV_EXEC_TESTS_CMD
         ${Coverage_EXECUTABLE} ${Coverage_EXECUTABLE_ARGS}
-    )    
+    )
     # Capturing lcov counters and generating report
-    set(LCOV_CAPTURE_CMD 
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b 
+    set(LCOV_CAPTURE_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --directory . -b
         ${BASEDIR} --capture --output-file ${Coverage_NAME}.capture
     )
     # add baseline counters
     set(LCOV_BASELINE_COUNT_CMD
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base 
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} -a ${Coverage_NAME}.base
         -a ${Coverage_NAME}.capture --output-file ${Coverage_NAME}.total
-    ) 
+    )
     # filter collected data to final coverage report
-    set(LCOV_FILTER_CMD 
-        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove 
+    set(LCOV_FILTER_CMD
+        ${LCOV_PATH} ${Coverage_LCOV_ARGS} --gcov-tool ${GCOV_PATH} --remove
         ${Coverage_NAME}.total ${LCOV_EXCLUDES} --output-file ${Coverage_NAME}.info
-    )    
+    )
     # Generate HTML output
     set(LCOV_GEN_HTML_CMD
-        ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o 
+        ${GENHTML_PATH} ${GENHTML_EXTRA_ARGS} ${Coverage_GENHTML_ARGS} -o
         ${Coverage_NAME} ${Coverage_NAME}.info
     )
     if(${Coverage_SONARQUBE})
@@ -306,7 +318,7 @@ function(setup_target_for_coverage_lcov)
         set(GCOVR_XML_CMD_BYPRODUCTS ${Coverage_NAME}_sonarqube.xml)
         set(GCOVR_XML_CMD_COMMENT COMMENT "SonarQube code coverage info report saved in ${Coverage_NAME}_sonarqube.xml.")
     endif()
-    
+
 
     if(CODE_COVERAGE_VERBOSE)
         message(STATUS "Executed command report")
@@ -348,11 +360,11 @@ function(setup_target_for_coverage_lcov)
     # Setup target
     add_custom_target(${Coverage_NAME}
         COMMAND ${LCOV_CLEAN_CMD}
-        COMMAND ${LCOV_BASELINE_CMD} 
+        COMMAND ${LCOV_BASELINE_CMD}
         COMMAND ${LCOV_EXEC_TESTS_CMD}
         COMMAND ${LCOV_CAPTURE_CMD}
         COMMAND ${LCOV_BASELINE_COUNT_CMD}
-        COMMAND ${LCOV_FILTER_CMD} 
+        COMMAND ${LCOV_FILTER_CMD}
         COMMAND ${LCOV_GEN_HTML_CMD}
         ${GCOVR_XML_CMD_COMMAND}
 
@@ -367,19 +379,19 @@ function(setup_target_for_coverage_lcov)
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
         VERBATIM # Protect arguments to commands
-        COMMENT "Resetting code coverage counters to zero.\nProcessing code coverage counters and generating report."
+        COMMENT "Resetting code coverage counters to zero. Processing code coverage counters and generating report."
     )
 
     # Show where to find the lcov info report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Lcov code coverage info report saved in ${Coverage_NAME}.info."
         ${GCOVR_XML_CMD_COMMENT}
     )
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 
@@ -435,7 +447,7 @@ function(setup_target_for_coverage_gcovr_xml)
         list(APPEND GCOVR_EXCLUDE_ARGS "-e")
         list(APPEND GCOVR_EXCLUDE_ARGS "${EXCLUDE}")
     endforeach()
-    
+
     # Set up commands which will be run to generate coverage data
     # Run tests
     set(GCOVR_XML_EXEC_TESTS_CMD
@@ -446,7 +458,7 @@ function(setup_target_for_coverage_gcovr_xml)
         ${GCOVR_PATH} --xml ${Coverage_NAME}.xml -r ${BASEDIR} ${GCOVR_ADDITIONAL_ARGS}
         ${GCOVR_EXCLUDE_ARGS} --object-directory=${PROJECT_BINARY_DIR}
     )
-    
+
     if(CODE_COVERAGE_VERBOSE)
         message(STATUS "Executed command report")
 
@@ -462,7 +474,7 @@ function(setup_target_for_coverage_gcovr_xml)
     add_custom_target(${Coverage_NAME}
         COMMAND ${GCOVR_XML_EXEC_TESTS_CMD}
         COMMAND ${GCOVR_XML_CMD}
-        
+
         BYPRODUCTS ${Coverage_NAME}.xml
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
         DEPENDS ${Coverage_DEPENDENCIES}
@@ -472,7 +484,7 @@ function(setup_target_for_coverage_gcovr_xml)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Cobertura code coverage report saved in ${Coverage_NAME}.xml."
     )
 endfunction() # setup_target_for_coverage_gcovr_xml
@@ -573,7 +585,7 @@ function(setup_target_for_coverage_gcovr_html)
 
     # Show info where to find the report
     add_custom_command(TARGET ${Coverage_NAME} POST_BUILD
-        COMMAND ;
+        COMMAND true
         COMMENT "Open ./${Coverage_NAME}/index.html in your browser to view the coverage report."
     )
 
@@ -638,9 +650,8 @@ function(setup_target_for_coverage_fastcov)
         --process-gcno
         --output ${Coverage_NAME}.json
         --exclude ${FASTCOV_EXCLUDES}
-        --exclude ${FASTCOV_EXCLUDES}
     )
-    
+
     set(FASTCOV_CONVERT_CMD ${FASTCOV_PATH}
         -C ${Coverage_NAME}.json --lcov --output ${Coverage_NAME}.info
     )
@@ -731,6 +742,9 @@ endfunction() # append_coverage_compiler_flags
 
 # Setup coverage for specific library
 function(append_coverage_compiler_flags_to_target name)
-    target_compile_options(${name}
-        PRIVATE ${COVERAGE_COMPILER_FLAGS})
+    separate_arguments(_flag_list NATIVE_COMMAND "${COVERAGE_COMPILER_FLAGS}")
+    target_compile_options(${name} PRIVATE ${_flag_list})
+    if(CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries(${name} PRIVATE gcov)
+    endif()
 endfunction()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Upload coverage
         if: ${{ env.SIGNALS_COVERAGE == 'On' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           gcov: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,13 +27,14 @@ jobs:
           - os: windows-latest
             compiler: msvc
 
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             compiler: clang
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             compiler: gcc
-          - os: ubuntu-20.04
+          
+          - os: ubuntu-22.04
             compiler: clang
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             compiler: gcc
 
           - os: macos-latest
@@ -45,7 +46,7 @@ jobs:
           submodules: true
 
       - name: Enable coverage
-        if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-22.04'
+        if: matrix.compiler == 'gcc' && matrix.os == 'ubuntu-24.04'
         run: |
             echo "SIGNALS_COVERAGE=On" >> "$GITHUB_ENV"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.7.2)
+cmake_minimum_required(VERSION 3.7...4.0)
 
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_EXPORT_COMPILE_COMMANDS YES)


### PR DESCRIPTION
- ClangFormat config included a duplicate line which made the config invalid - it also contained a dictionary literal without commas
- The OS versions were out of date and included unavailable runners
- CodeCoverage didn't work with modern CMake
- codecov was using an outdated action
- gtest didn't work with CMake 4.0
- CMake didn't specify a version range, so 4.0 issued a warning