### PR TITLE
build: use CMake GTest support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Test
         working-directory: ./build
-        run: ctest
+        run: ctest --output-on-failure
 
       - name: Generate coverage
         if: ${{ env.SIGNALS_COVERAGE == 'On' }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,8 @@ if (BUILD_TESTS)
 
     target_link_libraries(signals-test gtest PajladaSignals)
 
-    add_test(UnitTests signals-test)
+    include(GoogleTest)
+    gtest_discover_tests(signals-test)
 
     if (BUILD_COVERAGE)
         include(CodeCoverage)


### PR DESCRIPTION
CMake can add tests for us, so let's use that.