### PR TITLE
ci: schedule a daily build run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
       - master
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 1 * * *'
 
 concurrency:
   group: build-${{ github.ref }}


### PR DESCRIPTION
this just ensures we don't randomly start breaking because of some system dependency update, or workflow suddenly not working
