### PR TITLE
chore: remove unused `Signal::disconnectAll`

### DIFF
--- a/include/pajlada/signals/signal.hpp
+++ b/include/pajlada/signals/signal.hpp
@@ -40,14 +40,6 @@ public:
         }
     }
 
-    void
-    disconnectAll()
-    {
-        std::unique_lock<std::mutex> lock(this->callbackBodiesMutex);
-
-        this->callbackBodies.clear();
-    }
-
 private:
     std::mutex callbackBodiesMutex;
     std::vector<std::shared_ptr<CallbackBodyType>> callbackBodies;

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -59,37 +59,3 @@ TEST(Signal, MultipleConnect)
 
     EXPECT_EQ(a, 6);
 }
-
-TEST(Signal, DisconnectAll)
-{
-    Signal<int> signal;
-
-    int a = 0;
-    auto cb = [&](int i) { a += i; };
-
-    EXPECT_EQ(a, 0);
-
-    signal.invoke(1);
-
-    EXPECT_EQ(a, 0);
-
-    auto connA = signal.connect(cb);
-    auto connB = signal.connect(cb);
-
-    signal.invoke(1);
-    EXPECT_EQ(a, 2);
-
-    Connection connACopy = connA;
-
-    signal.invoke(1);
-    EXPECT_EQ(a, 4);
-
-    EXPECT_EQ(connA.getSubscriberRefCount().connected, true);
-    EXPECT_EQ(connA.getSubscriberRefCount().count, 2);
-    signal.disconnectAll();
-
-    signal.invoke(1);
-    EXPECT_EQ(a, 4);
-    EXPECT_EQ(connA.getSubscriberRefCount().connected, false);
-    EXPECT_EQ(connA.getSubscriberRefCount().count, 0);
-}


### PR DESCRIPTION
If a signal had connections with a ref-count greater than one, `disconnectAll` would not disconnect all connections. We now clear the connections in `disconnectAll`. That function wasn't used in the two projects on GitHub.

On a more general note: why do connections even have a ref-count? Or: Why would one want multiple references to a connection? A connection is always associated with some function (almost always a lambda). This usually has one owner (not two or more).