### PR TITLE
dev: use CMake's FetchContent for declaring gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.7...4.0)
 
-option(PAJLADA_SIGNALS_BUILD_TESTS "pajlada signals build tests" OFF)
+include(FeatureSummary)
+
+option(PAJLADA_SIGNALS_BUILD_TESTS "Build tests" OFF)
+add_feature_info("pajlada-signals tests" PAJLADA_SIGNALS_BUILD_TESTS "")
 
 set(CMAKE_BUILD_TYPE Debug)
 set(CMAKE_EXPORT_COMPILE_COMMANDS YES)
@@ -17,5 +20,8 @@ set(CMAKE_CXX_STANDARD 17)
 # set_property(TARGET signals-test PROPERTY CXX_STANDARD_REQUIRED ON)
 
 if(PAJLADA_SIGNALS_BUILD_TESTS)
+    enable_testing()
     add_subdirectory(tests)
 endif()
+
+feature_summary(WHAT ALL)

--- a/README.md
+++ b/README.md
@@ -19,3 +19,28 @@ s.disconnect(cX);
 s.invoke(1, 2);
     
 ```
+
+## Development
+
+```sh
+# Create build dir
+mkdir build
+cd build
+
+cmake \
+    -DPAJLADA_SIGNALS_BUILD_TESTS=On \
+    -DPAJLADA_SIGNALS_BUILD_COVERAGE=On \
+    ..
+
+# Build
+cmake --build .
+
+# Run tests
+ctest
+
+# Generate coverage
+make coverage
+
+# Open generated coverage in your browser
+firefox tests/coverage/index.html
+```

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,18 +1,32 @@
-option(PAJLADA_SIGNALS_BUILD_COVERAGE "pajlada signals build coverage" OFF)
+cmake_minimum_required(VERSION 3.7...4.0)
+
+project(signals-test)
+
+option(PAJLADA_SIGNALS_BUILD_COVERAGE "Build coverage" OFF)
+add_feature_info("pajlada-signals coverage" PAJLADA_SIGNALS_BUILD_COVERAGE "")
 
 # For MSVC: Prevent overriding the parent project's compiler/linker settings
 # See https://github.com/google/googletest/blob/main/googletest/README.md#visual-studio-dynamic-vs-static-runtimes
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
-message("++ Tests enabled")
+include(FetchContent)
 
-add_subdirectory(${CMAKE_SOURCE_DIR}/external/googletest googletest)
+FetchContent_Declare(
+    googletest
+    URL ${CMAKE_CURRENT_LIST_DIR}/../external/googletest
+    EXCLUDE_FROM_ALL
+    FIND_PACKAGE_ARGS NAMES GTest
+)
+
+FetchContent_MakeAvailable(googletest)
+
+include(GoogleTest)
 
 enable_testing()
 
 include_directories(${gtest_SOURCE_DIR}/include ${gtest_SOURCE_DIR})
 
-add_executable(signals-test
+add_executable(${PROJECT_NAME}
     src/main.cpp
     src/signal.cpp
     src/self-disconnecting-signal.cpp
@@ -21,10 +35,10 @@ add_executable(signals-test
     src/signalholder.cpp
     )
 
-target_link_libraries(signals-test gtest PajladaSignals)
+target_link_libraries(${PROJECT_NAME} PRIVATE gtest)
+target_link_libraries(${PROJECT_NAME} PRIVATE PajladaSignals)
 
-include(GoogleTest)
-gtest_discover_tests(signals-test)
+gtest_discover_tests(${PROJECT_NAME})
 
 if (PAJLADA_SIGNALS_BUILD_COVERAGE)
     list(APPEND CMAKE_MODULE_PATH
@@ -32,11 +46,10 @@ if (PAJLADA_SIGNALS_BUILD_COVERAGE)
     )
     include(CodeCoverage)
     append_coverage_compiler_flags()
-    message("++ Coverage enabled (${CMAKE_CXX_COMPILER_ID})")
 
     setup_target_for_coverage_gcovr_html(
         NAME coverage
-        EXECUTABLE signals-test
+        EXECUTABLE ${PROJECT_NAME}
         EXCLUDE "external/*" "tests/src/*"
         )
 endif()


### PR DESCRIPTION
This still uses the submodule if necessary

Dependency order:
1. find_package (so system library)
2. our submodule
